### PR TITLE
Fix case matching strategy for readHeader regex

### DIFF
--- a/Payutc/Client/JsonClient.php
+++ b/Payutc/Client/JsonClient.php
@@ -54,7 +54,7 @@ class JsonClient
 
     public function readHeader($ch, $header)
     {
-        preg_match('/^Set-Cookie: (.*?)=(.*?);/m', $header, $capturedArgs);
+        preg_match('/^Set-Cookie: (.*?)=(.*?);/mi', $header, $capturedArgs);
         if (array_key_exists(1, $capturedArgs) and array_key_exists(2, $capturedArgs)) {
             $this->cookies[$capturedArgs[1]] = $capturedArgs[1] . '=' . $capturedArgs[2];
         }


### PR DESCRIPTION
Header names should be case insensitive (fix for Polar)